### PR TITLE
Improve video quality and add more quality options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+ffmpeg2pass-0.log
+test

--- a/Readme.md
+++ b/Readme.md
@@ -37,10 +37,13 @@ Options:
   -e, --exclude-pattern <pattern>  exclude pattern from source folder search (separate multiple patterns with comma) (default: "node_modules/**")
   -p, --pattern <pattern>          doc files pattern (default: "**/*.md")
   -t, --template <path>            template file holding the WebM player html code (default: "./template.html")
-  -q, --quality <number>           output quality, ranges between 0-63, lower means better quality (default: "40")
+  -q, --quality <number>           output quality, ranges between 0-63, lower means better quality (default: "18")
   -c, --skip-gif-conversion        set this flag to skip the conversion of GIF files to WebM (default: false)
   -r, --skip-doc-replace           set this flag to skip the doc search and replace step (default: false)
   -d, --delete-gif-files           set this flag to delete the original GIF files after conversion (default: false)
+  --max-fps <number>               maximum FPS (default: "15")
+  --max-width <number>             maximum video width (default: "1920")
+  --max-height <number>            maximum video height (default: "1080")
   -h, --help                       display help for command
 ```
 

--- a/src/convertGifToWebM.ts
+++ b/src/convertGifToWebM.ts
@@ -1,23 +1,84 @@
-import * as fs from "fs";
 import ffmpeg from "js-ffmpeg";
 import chalk from "chalk";
 
-const convertSingleGifFileToWebM = (gifFile: string, quality: number) => {
+const convertSingleGifFileToWebM = (
+  gifFile: string,
+  { quality, maxFps, maxWidth, maxHeight }: ParsedQualityOptions
+) => {
   console.info(chalk.dim(`converting file '${gifFile}'...`));
   const folder = gifFile.split("/").slice(0, -1).join("/");
   const fileName = gifFile.split("/").pop()?.split(".").slice(0, -1).join(".");
   return new Promise<string>((resolve, reject) => {
     ffmpeg
-      .ffmpeg(
-        gifFile,
-        ["-c", "vp9", "-b:v", "0", "-crf", `${quality}`],
-        `${folder}/${fileName}.webm`
-      )
+      .ffprobe(gifFile)
       // @ts-ignore
-      .success(() => resolve(`${folder}/${fileName}.webm`))
-      .error(function (error: any) {
+      .success((json) => {
+        let fps: string | undefined =
+          json.streams[0]?.r_frame_rate?.split("/")[0];
+        const parsedFps = fps && parseInt(fps);
+        const targetFps = parsedFps && parsedFps < maxFps ? parsedFps : maxFps;
+
+        ffmpeg
+          .ffmpeg(
+            gifFile,
+            [
+              "-c",
+              "vp9",
+              "-b:v",
+              "0",
+              "-crf",
+              `${quality}`,
+              "-pass",
+              "1",
+              "-an",
+              "-f",
+              "null",
+            ],
+            "/dev/null"
+          )
+          // @ts-ignore
+          .success(() => {
+            ffmpeg
+              .ffmpeg(
+                gifFile,
+                [
+                  "-c",
+                  "vp9",
+                  "-b:v",
+                  "0",
+                  "-crf",
+                  `${quality}`,
+                  "-pass",
+                  "2",
+                  "-an",
+                  "-vf",
+                  `scale='min(${maxWidth},iw)':min'(${maxHeight},ih)':force_original_aspect_ratio=decrease,fps=${targetFps}`,
+                ],
+                `${folder}/${fileName}.webm`
+              )
+              // @ts-ignore
+              .success(() => resolve(`${folder}/${fileName}.webm`))
+              .error((error: any) => {
+                console.error(
+                  chalk.red(
+                    `ffmpeg error while processing '${gifFile}' - pass 2`
+                  ),
+                  error
+                );
+                reject(error);
+              });
+          })
+          .error((error: any) => {
+            console.error(
+              chalk.red(`ffmpeg error while processing '${gifFile}' - pass 1`),
+              error
+            );
+            reject(error);
+          });
+      })
+      .error((error: any) => {
         console.error(
-          chalk.red(`ffmpeg error while processing '${gifFile}'`),
+          chalk.red(`ffmpeg error while probing '${gifFile}' with ffprobe`),
           error
         );
         reject(error);
@@ -25,21 +86,43 @@ const convertSingleGifFileToWebM = (gifFile: string, quality: number) => {
   });
 };
 
+interface ParsedQualityOptions {
+  quality: number;
+  maxFps: number;
+  maxWidth: number;
+  maxHeight: number;
+}
+
 export const convertGifFilesToWebM = async (
   sourceFolder: string,
   gifFiles: string[],
-  quality: string
+  { quality, maxFps, maxWidth, maxHeight }: QualityOptions
 ) => {
-  const parsedQuality = parseInt(quality) || 40;
+  const parsedQuality = (quality && parseInt(quality)) || 18;
+  const parsedMaxFps = (maxFps && parseInt(maxFps)) || 15;
+  const parsedMaxWidth = (maxWidth && parseInt(maxWidth)) || 1920;
+  const parsedMaxHeight = (maxHeight && parseInt(maxHeight)) || 1080;
   // It seems better to process the files one at a time because otherwise
   // the ffmpeg processes are very resource intensive and can freeze the host.
   const webmFiles: string[] = [];
   for (const file of gifFiles) {
     const webmFile = await convertSingleGifFileToWebM(
       `${sourceFolder}/${file}`,
-      parsedQuality
+      {
+        quality: parsedQuality,
+        maxFps: parsedMaxFps,
+        maxWidth: parsedMaxWidth,
+        maxHeight: parsedMaxHeight,
+      }
     );
     webmFiles.push(webmFile);
   }
   return webmFiles;
 };
+
+interface QualityOptions {
+  quality?: string;
+  maxFps?: string;
+  maxWidth?: string;
+  maxHeight?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ program
   .option(
     "-q, --quality <number>",
     "output quality, ranges between 0-63, lower means better quality",
-    "40"
+    "18"
   )
   .option(
     "-c, --skip-gif-conversion",
@@ -46,6 +46,9 @@ program
     "set this flag to delete the original GIF files after conversion",
     false
   )
+  .option("--max-fps <number>", "maximum FPS", "15")
+  .option("--max-width <number>", "maximum video width", "1920")
+  .option("--max-height <number>", "maximum video height", "1080")
   .action(async (options) => {
     const {
       folder,
@@ -56,6 +59,9 @@ program
       skipGifConversion,
       skipDocReplace,
       deleteGifFiles,
+      maxFps,
+      maxWidth,
+      maxHeight,
     } = options;
     console.log(chalk.dim("Parsed options:"));
     console.log(chalk.dim(`folder: ${folder}`));
@@ -66,6 +72,9 @@ program
     console.log(chalk.dim(`skipGifConversion: ${skipGifConversion}`));
     console.log(chalk.dim(`skipDocReplace: ${skipDocReplace}`));
     console.log(chalk.dim(`deleteGifFiles: ${deleteGifFiles}`));
+    console.log(chalk.dim(`maxFps: ${maxFps}`));
+    console.log(chalk.dim(`maxWidth: ${maxWidth}`));
+    console.log(chalk.dim(`maxHeight: ${maxHeight}`));
     console.log();
 
     try {
@@ -81,11 +90,12 @@ program
       );
 
       if (!skipGifConversion) {
-        const convertedFiles = await convertGifFilesToWebM(
-          folder,
-          gifFiles,
-          quality
-        );
+        const convertedFiles = await convertGifFilesToWebM(folder, gifFiles, {
+          quality,
+          maxFps,
+          maxWidth,
+          maxHeight,
+        });
         console.info(
           chalk.green(
             `Successfully converted ${chalk.bold(convertedFiles.length)} files`


### PR DESCRIPTION
- [x] Implement 2-pass encoding for better quality (following [VP9 codec doc recommendations](https://trac.ffmpeg.org/wiki/Encode/VP9))
- [x] Increase default CRF to 18
- [x] Implement more quality options: `maxFps`, `maxWidth` and `maxHeight`